### PR TITLE
Substantial performance improvement of AnyPawnBlockingMapRemoval Patch

### DIFF
--- a/Source/CM_PocketDimension/Buildings/Building_PocketDimensionBox.cs
+++ b/Source/CM_PocketDimension/Buildings/Building_PocketDimensionBox.cs
@@ -76,7 +76,7 @@ namespace CM_PocketDimension
         public override void SpawnSetup(Map map, bool respawningAfterLoad)
         {
             base.SpawnSetup(map, respawningAfterLoad);
-
+            map.GetComponent<Comps.MapComponent_PocketDimension>().Building_PocketDimensionBoxes.Add(this);
             Logger.MessageFormat(this, "Spawning");
 
             compCreator = this.GetComp<CompPocketDimensionCreator>();
@@ -141,7 +141,6 @@ namespace CM_PocketDimension
         public override void Destroy(DestroyMode mode = DestroyMode.Vanish)
         {
             base.Destroy(mode);
-
             MapParent_PocketDimension dimensionMapParent = null;
 
             if (!string.IsNullOrEmpty(dimensionSeed) && PocketDimensionUtility.MapParents.TryGetValue(dimensionSeed, out dimensionMapParent))
@@ -600,6 +599,12 @@ namespace CM_PocketDimension
             }
 
             return result;
+        }
+
+        public override void DeSpawn(DestroyMode mode = DestroyMode.Vanish)
+        {
+            base.DeSpawn(mode);
+            this.Map.GetComponent<Comps.MapComponent_PocketDimension>().Building_PocketDimensionBoxes.Remove(this);
         }
     }
 }

--- a/Source/CM_PocketDimension/Buildings/Building_PocketDimensionBox.cs
+++ b/Source/CM_PocketDimension/Buildings/Building_PocketDimensionBox.cs
@@ -603,8 +603,8 @@ namespace CM_PocketDimension
 
         public override void DeSpawn(DestroyMode mode = DestroyMode.Vanish)
         {
-            base.DeSpawn(mode);
             this.Map.GetComponent<Comps.MapComponent_PocketDimension>().Building_PocketDimensionBoxes.Remove(this);
+            base.DeSpawn(mode);
         }
     }
 }

--- a/Source/CM_PocketDimension/CM_PocketDimension.csproj
+++ b/Source/CM_PocketDimension/CM_PocketDimension.csproj
@@ -31,14 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="0Harmony, Version=2.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Lib.Harmony.2.2.1\lib\net472\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -48,14 +42,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.3.3287" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Buildings\Building_PocketDimensionEmpty.cs" />
@@ -68,6 +55,7 @@
     <Compile Include="Comps\CompProperties_PocketDimensionBatteryShare.cs" />
     <Compile Include="Comps\CompPocketDimensionBatteryShare.cs" />
     <Compile Include="Comps\CompProperties_PocketDimensionCreator.cs" />
+    <Compile Include="Comps\MapComponent_PocketDimension.cs" />
     <Compile Include="DebugActions\Debug_SummonTradeShip.cs" />
     <Compile Include="DefPatches.cs" />
     <Compile Include="Dialog_RenamePocketDimensionEntranceBase.cs" />
@@ -98,6 +86,9 @@
     <Compile Include="Buildings\Building_PocketDimensionExit.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StatPatches.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/CM_PocketDimension/Comps/MapComponent_PocketDimension.cs
+++ b/Source/CM_PocketDimension/Comps/MapComponent_PocketDimension.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+using RimWorld;
+
+namespace CM_PocketDimension.Comps
+{
+    class MapComponent_PocketDimension : MapComponent
+    {
+        public List<Building_PocketDimensionBox> Building_PocketDimensionBoxes { get; set; } = new List<Building_PocketDimensionBox>();
+
+
+             
+        public MapComponent_PocketDimension(Map map) : base(map)
+        {
+
+        }
+    }
+}

--- a/Source/CM_PocketDimension/Map/MapPatches.cs
+++ b/Source/CM_PocketDimension/Map/MapPatches.cs
@@ -44,12 +44,11 @@ namespace CM_PocketDimension
             [HarmonyPrefix]
             public static bool Prefix(MapPawns __instance, Map ___map, ref bool __result)
             {
-                // Check all pocket dimensions accessible to this map and allow their contents to block this maps removal
-                List<Thing> pocketDimensionBoxes = ___map.listerThings.AllThings.Where(thing => thing as Building_PocketDimensionBox != null).ToList();
+                // Check MapComponent for spawnd Building_PocketDimensionBox
+                List<Building_PocketDimensionBox> pocketDimensionBoxes = ___map.GetComponent<Comps.MapComponent_PocketDimension>().Building_PocketDimensionBoxes;
 
-                foreach (Thing thing in pocketDimensionBoxes)
+                foreach (Building_PocketDimensionBox box in pocketDimensionBoxes)
                 {
-                    Building_PocketDimensionBox box = thing as Building_PocketDimensionBox;
                     if (box != null)
                     {
                         Building_PocketDimensionEntranceBase boxExit = PocketDimensionUtility.GetOtherSide(box);

--- a/Source/CM_PocketDimension/packages.config
+++ b/Source/CM_PocketDimension/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Lib.Harmony" version="2.2.1" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
The `AnyPawnBlockingMapRemoval` is performance heavy as it performs a check on each thing on a map to see if that Thing is of the type `Building_PocketDimensionBox`.

With this Change a `Building_PocketDimensionBox` will register itself on the `MapComponent_PocketDimension` on spawn & remove itself on despawn. Therefor the patch now only has to check the Map Component to get a list of all `Building_PocketDimensionBox` on said map.

**Before the update**
![PreChange](https://user-images.githubusercontent.com/68663281/159133005-3ab25fa0-bcf5-4dfa-88d5-58d75e36e2a7.png)

**After the update**
![PostChange2](https://user-images.githubusercontent.com/68663281/159133101-c1fe2f6f-2f6d-4468-b16d-1604638b4b8d.png)

